### PR TITLE
Replace restrict keyword with __restrict__

### DIFF
--- a/src/scrypt/sha256.c
+++ b/src/scrypt/sha256.c
@@ -94,9 +94,9 @@ static const uint32_t Krnd[64] = {
  * the 512-bit input block to produce a new state.
  */
 static void
-SHA256_Transform(uint32_t state[static restrict 8],
-    const uint8_t block[static restrict 64],
-    uint32_t W[static restrict 64], uint32_t S[static restrict 8])
+SHA256_Transform(uint32_t state[static __restrict__ 8],
+    const uint8_t block[static __restrict__ 64],
+    uint32_t W[static __restrict__ 64], uint32_t S[static __restrict__ 8])
 {
 	int i;
 
@@ -159,7 +159,7 @@ static const uint8_t PAD[64] = {
 
 /* Add padding and terminating bit-count. */
 static void
-SHA256_Pad(SHA256_CTX * ctx, uint32_t tmp32[static restrict 72])
+SHA256_Pad(SHA256_CTX * ctx, uint32_t tmp32[static __restrict__ 72])
 {
 	size_t r;
 
@@ -213,7 +213,7 @@ SHA256_Init(SHA256_CTX * ctx)
  */
 static void
 _SHA256_Update(SHA256_CTX * ctx, const void * in, size_t len,
-    uint32_t tmp32[static restrict 72])
+    uint32_t tmp32[static __restrict__ 72])
 {
 	uint32_t r;
 	const uint8_t * src = in;
@@ -271,7 +271,7 @@ SHA256_Update(SHA256_CTX * ctx, const void * in, size_t len)
  */
 static void
 _SHA256_Final(uint8_t digest[32], SHA256_CTX * ctx,
-    uint32_t tmp32[static restrict 72])
+    uint32_t tmp32[static __restrict__ 72])
 {
 
 	/* Add padding. */
@@ -323,8 +323,8 @@ SHA256_Buf(const void * in, size_t len, uint8_t digest[32])
  */
 static void
 _HMAC_SHA256_Init(HMAC_SHA256_CTX * ctx, const void * _K, size_t Klen,
-    uint32_t tmp32[static restrict 72], uint8_t pad[static restrict 64],
-    uint8_t khash[static restrict 32])
+    uint32_t tmp32[static __restrict__ 72], uint8_t pad[static __restrict__ 64],
+    uint8_t khash[static __restrict__ 32])
 {
 	const uint8_t * K = _K;
 	size_t i;
@@ -376,7 +376,7 @@ HMAC_SHA256_Init(HMAC_SHA256_CTX * ctx, const void * _K, size_t Klen)
  */
 static void
 _HMAC_SHA256_Update(HMAC_SHA256_CTX * ctx, const void * in, size_t len,
-    uint32_t tmp32[static restrict 72])
+    uint32_t tmp32[static __restrict__ 72])
 {
 
 	/* Feed data to the inner SHA256 operation. */
@@ -403,7 +403,7 @@ HMAC_SHA256_Update(HMAC_SHA256_CTX * ctx, const void * in, size_t len)
  */
 static void
 _HMAC_SHA256_Final(uint8_t digest[32], HMAC_SHA256_CTX * ctx,
-    uint32_t tmp32[static restrict 72], uint8_t ihash[static restrict 32])
+    uint32_t tmp32[static __restrict__ 72], uint8_t ihash[static __restrict__ 32])
 {
 
 	/* Finish the inner SHA256 operation. */


### PR DESCRIPTION
Apparently the restrict keyword is not recognized by some C++ compilers.  This was causing a compilation failure on my ubuntu machine.  From what I was reading, it'd probably be safe to remove the restrict keyword altogether but I wasn't 100% sure on that. Another option might be to adjust the cflags in the binding.gyp file to use -std=c99 for the .c files but  I couldn't get that working properly.

```
adam@lappy:~/bcoin-native$ npm install

> bcoin-native@0.0.5 install /home/adam/bcoin-native
> node-gyp rebuild

make: Entering directory `/home/adam/bcoin-native/build'
  CC(target) Release/obj.target/bcoin-native/src/poly1305-donna/poly1305-donna.o
  CC(target) Release/obj.target/bcoin-native/src/chacha20-simple/chacha20_simple.o
  CC(target) Release/obj.target/bcoin-native/src/scrypt/insecure_memzero.o
  CC(target) Release/obj.target/bcoin-native/src/scrypt/sha256.o
../src/scrypt/sha256.c:97:40: error: ‘restrict’ undeclared here (not in a function)
 SHA256_Transform(uint32_t state[static restrict 8],
                                        ^
../src/scrypt/sha256.c:97:49: error: expected ‘]’ before numeric constant
 SHA256_Transform(uint32_t state[static restrict 8],
                                                 ^
../src/scrypt/sha256.c:98:5: error: expected ‘;’, ‘,’ or ‘)’ before ‘const’
     const uint8_t block[static restrict 64],
     ^
../src/scrypt/sha256.c:162:52: error: ‘restrict’ undeclared here (not in a function)
 SHA256_Pad(SHA256_CTX * ctx, uint32_t tmp32[static restrict 72])
                                                    ^
../src/scrypt/sha256.c:162:61: error: expected ‘]’ before numeric constant
 SHA256_Pad(SHA256_CTX * ctx, uint32_t tmp32[static restrict 72])
                                                             ^
../src/scrypt/sha256.c:216:27: error: ‘restrict’ undeclared here (not in a function)
     uint32_t tmp32[static restrict 72])
                           ^
../src/scrypt/sha256.c:216:36: error: expected ‘]’ before numeric constant
     uint32_t tmp32[static restrict 72])
                                    ^
../src/scrypt/sha256.c: In function ‘libcperciva_SHA256_Update’:
../src/scrypt/sha256.c:261:2: warning: implicit declaration of function ‘_SHA256_Update’ [-Wimplicit-function-declaration]
  _SHA256_Update(ctx, in, len, tmp32);
  ^
../src/scrypt/sha256.c: At top level:
../src/scrypt/sha256.c:274:27: error: ‘restrict’ undeclared here (not in a function)
     uint32_t tmp32[static restrict 72])
                           ^
../src/scrypt/sha256.c:274:36: error: expected ‘]’ before numeric constant
     uint32_t tmp32[static restrict 72])
                                    ^
../src/scrypt/sha256.c: In function ‘libcperciva_SHA256_Final’:
../src/scrypt/sha256.c:291:2: warning: implicit declaration of function ‘_SHA256_Final’ [-Wimplicit-function-declaration]
  _SHA256_Final(digest, ctx, tmp32);
  ^
../src/scrypt/sha256.c: At top level:
../src/scrypt/sha256.c:326:27: error: ‘restrict’ undeclared here (not in a function)
     uint32_t tmp32[static restrict 72], uint8_t pad[static restrict 64],
                           ^
../src/scrypt/sha256.c:326:36: error: expected ‘]’ before numeric constant
     uint32_t tmp32[static restrict 72], uint8_t pad[static restrict 64],
                                    ^
../src/scrypt/sha256.c:326:41: error: expected ‘;’, ‘,’ or ‘)’ before ‘uint8_t’
     uint32_t tmp32[static restrict 72], uint8_t pad[static restrict 64],
                                         ^
../src/scrypt/sha256.c: In function ‘libcperciva_HMAC_SHA256_Init’:
../src/scrypt/sha256.c:365:2: warning: implicit declaration of function ‘_HMAC_SHA256_Init’ [-Wimplicit-function-declaration]
  _HMAC_SHA256_Init(ctx, _K, Klen, tmp32, pad, khash);
  ^
../src/scrypt/sha256.c: At top level:
../src/scrypt/sha256.c:379:27: error: ‘restrict’ undeclared here (not in a function)
     uint32_t tmp32[static restrict 72])
                           ^
../src/scrypt/sha256.c:379:36: error: expected ‘]’ before numeric constant
     uint32_t tmp32[static restrict 72])
                                    ^
../src/scrypt/sha256.c: In function ‘libcperciva_HMAC_SHA256_Update’:
../src/scrypt/sha256.c:393:2: warning: implicit declaration of function ‘_HMAC_SHA256_Update’ [-Wimplicit-function-declaration]
  _HMAC_SHA256_Update(ctx, in, len, tmp32);
  ^
../src/scrypt/sha256.c: At top level:
../src/scrypt/sha256.c:406:27: error: ‘restrict’ undeclared here (not in a function)
     uint32_t tmp32[static restrict 72], uint8_t ihash[static restrict 32])
                           ^
../src/scrypt/sha256.c:406:36: error: expected ‘]’ before numeric constant
     uint32_t tmp32[static restrict 72], uint8_t ihash[static restrict 32])
                                    ^
../src/scrypt/sha256.c:406:41: error: expected ‘;’, ‘,’ or ‘)’ before ‘uint8_t’
     uint32_t tmp32[static restrict 72], uint8_t ihash[static restrict 32])
                                         ^
../src/scrypt/sha256.c: In function ‘libcperciva_HMAC_SHA256_Final’:
../src/scrypt/sha256.c:427:2: warning: implicit declaration of function ‘_HMAC_SHA256_Final’ [-Wimplicit-function-declaration]
  _HMAC_SHA256_Final(digest, ctx, tmp32, ihash);
  ^
make: *** [Release/obj.target/bcoin-native/src/scrypt/sha256.o] Error 1
make: Leaving directory `/home/adam/bcoin-native/build'
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/home/adam/.node_modules/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:106:13)
gyp ERR! stack     at ChildProcess.emit (events.js:191:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)
gyp ERR! System Linux 3.13.0-33-generic
gyp ERR! command "/usr/local/bin/node" "/home/adam/.node_modules/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /home/adam/bcoin-native
gyp ERR! node -v v6.6.0
gyp ERR! node-gyp -v v3.4.0
gyp ERR! not ok

npm ERR! Linux 3.13.0-33-generic
npm ERR! argv "/usr/local/bin/node" "/home/adam/.node_modules/bin/npm" "install"
npm ERR! node v6.6.0
npm ERR! npm  v3.10.8
npm ERR! code ELIFECYCLE
npm ERR! bcoin-native@0.0.5 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the bcoin-native@0.0.5 install script 'node-gyp rebuild'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the bcoin-native package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp rebuild
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs bcoin-native
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls bcoin-native
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /home/adam/bcoin-native/npm-debug.log
```
