### PR TITLE
Apply -std=c99 to .c files

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -25,6 +25,9 @@
       "-Wextra",
       "-O3"
     ],
+    "cflags_c": [
+      "-std=c99"
+    ],
     "defines": [
       "POLY1305_64BIT"
     ],

--- a/src/scrypt/sha256.c
+++ b/src/scrypt/sha256.c
@@ -94,9 +94,9 @@ static const uint32_t Krnd[64] = {
  * the 512-bit input block to produce a new state.
  */
 static void
-SHA256_Transform(uint32_t state[static __restrict__ 8],
-    const uint8_t block[static __restrict__ 64],
-    uint32_t W[static __restrict__ 64], uint32_t S[static __restrict__ 8])
+SHA256_Transform(uint32_t state[static restrict 8],
+    const uint8_t block[static restrict 64],
+    uint32_t W[static restrict 64], uint32_t S[static restrict 8])
 {
 	int i;
 
@@ -159,7 +159,7 @@ static const uint8_t PAD[64] = {
 
 /* Add padding and terminating bit-count. */
 static void
-SHA256_Pad(SHA256_CTX * ctx, uint32_t tmp32[static __restrict__ 72])
+SHA256_Pad(SHA256_CTX * ctx, uint32_t tmp32[static restrict 72])
 {
 	size_t r;
 
@@ -213,7 +213,7 @@ SHA256_Init(SHA256_CTX * ctx)
  */
 static void
 _SHA256_Update(SHA256_CTX * ctx, const void * in, size_t len,
-    uint32_t tmp32[static __restrict__ 72])
+    uint32_t tmp32[static restrict 72])
 {
 	uint32_t r;
 	const uint8_t * src = in;
@@ -271,7 +271,7 @@ SHA256_Update(SHA256_CTX * ctx, const void * in, size_t len)
  */
 static void
 _SHA256_Final(uint8_t digest[32], SHA256_CTX * ctx,
-    uint32_t tmp32[static __restrict__ 72])
+    uint32_t tmp32[static restrict 72])
 {
 
 	/* Add padding. */
@@ -323,8 +323,8 @@ SHA256_Buf(const void * in, size_t len, uint8_t digest[32])
  */
 static void
 _HMAC_SHA256_Init(HMAC_SHA256_CTX * ctx, const void * _K, size_t Klen,
-    uint32_t tmp32[static __restrict__ 72], uint8_t pad[static __restrict__ 64],
-    uint8_t khash[static __restrict__ 32])
+    uint32_t tmp32[static restrict 72], uint8_t pad[static restrict 64],
+    uint8_t khash[static restrict 32])
 {
 	const uint8_t * K = _K;
 	size_t i;
@@ -376,7 +376,7 @@ HMAC_SHA256_Init(HMAC_SHA256_CTX * ctx, const void * _K, size_t Klen)
  */
 static void
 _HMAC_SHA256_Update(HMAC_SHA256_CTX * ctx, const void * in, size_t len,
-    uint32_t tmp32[static __restrict__ 72])
+    uint32_t tmp32[static restrict 72])
 {
 
 	/* Feed data to the inner SHA256 operation. */
@@ -403,7 +403,7 @@ HMAC_SHA256_Update(HMAC_SHA256_CTX * ctx, const void * in, size_t len)
  */
 static void
 _HMAC_SHA256_Final(uint8_t digest[32], HMAC_SHA256_CTX * ctx,
-    uint32_t tmp32[static __restrict__ 72], uint8_t ihash[static __restrict__ 32])
+    uint32_t tmp32[static restrict 72], uint8_t ihash[static restrict 32])
 {
 
 	/* Finish the inner SHA256 operation. */


### PR DESCRIPTION
It was bugging me so I figured out how to fix the build file instead of
changing to the **restrict** keyword
