### PR TITLE
This fixes build fails on Windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,7 @@
       "./src/chacha20-simple/chacha20_simple.c",
       "./src/scrypt/insecure_memzero.c",
       "./src/scrypt/sha256.c",
-      "./src/scrypt/scrypt.c",
+      "./src/scrypt/crypto_scrypt.c",
       "./src/chacha20.cc",
       "./src/poly1305.cc",
       "./src/hash.cc",
@@ -40,5 +40,17 @@
       "<(node_root_dir)/deps/openssl/openssl/include",
       "<!(node -e \"require('nan')\")"
     ],
+    'conditions': [
+				[
+					'OS == "win"', {						
+						'libraries': [
+							'-lC:/OpenSSL-Win64/lib/libeay32.lib',
+						],
+						'include_dirs': [							
+							'C:/OpenSSL-Win64/include',
+						],
+					},
+				],
+			],
   }]
 }

--- a/src/scrypt.cc
+++ b/src/scrypt.cc
@@ -1,6 +1,6 @@
 #include "scrypt.h"
 extern "C" {
-#include "scrypt/scrypt.h"
+#include "scrypt/crypto_scrypt.h"
 }
 
 bool

--- a/src/scrypt/crypto_scrypt.c
+++ b/src/scrypt/crypto_scrypt.c
@@ -35,7 +35,9 @@
 #include "sha256.h"
 #include "sysendian.h"
 
-#include "scrypt.h"
+#include "crypto_scrypt.h"
+
+
 
 static void blkcpy(uint8_t *, uint8_t *, size_t);
 static void blkxor(uint8_t *, uint8_t *, size_t);

--- a/src/scrypt/crypto_scrypt.h
+++ b/src/scrypt/crypto_scrypt.h
@@ -30,8 +30,9 @@
 #define _CRYPTO_SCRYPT_H_
 
 #include <stdint.h>
+#ifndef _WIN32
 #include <unistd.h>
-
+#endif
 /**
  * crypto_scrypt(passwd, passwdlen, salt, saltlen, N, r, p, buf, buflen):
  * Compute scrypt(passwd[0 .. passwdlen - 1], salt[0 .. saltlen - 1], N, r,

--- a/src/scrypt/sha256.c
+++ b/src/scrypt/sha256.c
@@ -94,9 +94,9 @@ static const uint32_t Krnd[64] = {
  * the 512-bit input block to produce a new state.
  */
 static void
-SHA256_Transform(uint32_t state[static restrict 8],
-    const uint8_t block[static restrict 64],
-    uint32_t W[static restrict 64], uint32_t S[static restrict 8])
+SHA256_Transform(uint32_t state[8],
+    const uint8_t block[64],
+    uint32_t W[64], uint32_t S[8])
 {
 	int i;
 
@@ -159,7 +159,7 @@ static const uint8_t PAD[64] = {
 
 /* Add padding and terminating bit-count. */
 static void
-SHA256_Pad(SHA256_CTX * ctx, uint32_t tmp32[static restrict 72])
+SHA256_Pad(SHA256_CTX * ctx, uint32_t tmp32[72])
 {
 	size_t r;
 
@@ -213,7 +213,7 @@ SHA256_Init(SHA256_CTX * ctx)
  */
 static void
 _SHA256_Update(SHA256_CTX * ctx, const void * in, size_t len,
-    uint32_t tmp32[static restrict 72])
+    uint32_t tmp32[72])
 {
 	uint32_t r;
 	const uint8_t * src = in;
@@ -271,7 +271,7 @@ SHA256_Update(SHA256_CTX * ctx, const void * in, size_t len)
  */
 static void
 _SHA256_Final(uint8_t digest[32], SHA256_CTX * ctx,
-    uint32_t tmp32[static restrict 72])
+    uint32_t tmp32[72])
 {
 
 	/* Add padding. */
@@ -323,8 +323,8 @@ SHA256_Buf(const void * in, size_t len, uint8_t digest[32])
  */
 static void
 _HMAC_SHA256_Init(HMAC_SHA256_CTX * ctx, const void * _K, size_t Klen,
-    uint32_t tmp32[static restrict 72], uint8_t pad[static restrict 64],
-    uint8_t khash[static restrict 32])
+    uint32_t tmp32[72], uint8_t pad[64],
+    uint8_t khash[32])
 {
 	const uint8_t * K = _K;
 	size_t i;
@@ -376,7 +376,7 @@ HMAC_SHA256_Init(HMAC_SHA256_CTX * ctx, const void * _K, size_t Klen)
  */
 static void
 _HMAC_SHA256_Update(HMAC_SHA256_CTX * ctx, const void * in, size_t len,
-    uint32_t tmp32[static restrict 72])
+    uint32_t tmp32[72])
 {
 
 	/* Feed data to the inner SHA256 operation. */
@@ -403,7 +403,7 @@ HMAC_SHA256_Update(HMAC_SHA256_CTX * ctx, const void * in, size_t len)
  */
 static void
 _HMAC_SHA256_Final(uint8_t digest[32], HMAC_SHA256_CTX * ctx,
-    uint32_t tmp32[static restrict 72], uint8_t ihash[static restrict 32])
+    uint32_t tmp32[72], uint8_t ihash[32])
 {
 
 	/* Finish the inner SHA256 operation. */


### PR DESCRIPTION
Removed ```static restricted``` keyword from ```scrypt/sha256.c``` for compiler errors. Any suggestion /cc @chjj ?

added #ifndef _WIN32 for unistd.h in scrytp/crypto.h, we won't find
unistd.h on a Windows system.

Added OS == "win" condition to bindings.gyp for windows OpenSSL
libraries include path.

Renamed scrypt/scrypt.* to scrypt/crypto_scrypt.* I don't know why but
Windows confused and can not include scrypt.h and scrypt/scrypt.h same
time.